### PR TITLE
Update index.scss

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -150,6 +150,7 @@ body.toastr-confirm-active {
       outline: none;
       opacity: 0.5;
       cursor: pointer;
+      font-family: "Helvetica Neue", Helvetica, Arial sans-serif;
 
       &:hover {
         opacity: 1;


### PR DESCRIPTION
Depending on the installation, chrome may struggle to render the Unicode Character 'MULTIPLICATION X' (U+2715) used in the close button tag. 

A quick fix, add:
`font-family: "Helvetica Neue", Helvetica, Arial sans-serif;`
to 
`.redux-toastr .toastr .close-toastr{}`